### PR TITLE
Use googletest v1.16 for newer versions of CMake.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,7 +63,7 @@ if(PROXYRES_BUILD_TESTS)
             if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 5.3)
                 set(GTEST_TAG release-1.10.0)
             else()
-                set(GTEST_TAG release-1.11.0)
+                set(GTEST_TAG v1.16.0)
             endif()
         endif()
 


### PR DESCRIPTION
To avoid CMake warning about min-requirements for old version.